### PR TITLE
Escape string in the error message

### DIFF
--- a/src/MICmdBase.cpp
+++ b/src/MICmdBase.cpp
@@ -190,7 +190,8 @@ void CMICmdBase::SetError(const CMIUtilString &rErrMsg) {
   m_cmdData.strErrorDescription = rErrMsg;
   m_cmdData.bCmdExecutedSuccessfully = false;
 
-  const CMICmnMIValueResult valueResult("msg", CMICmnMIValueConst(rErrMsg));
+  const CMICmnMIValueResult valueResult(
+      "msg", CMICmnMIValueConst(rErrMsg.Escape(true)));
   const CMICmnMIResultRecord miResultRecord(
       m_cmdData.strMiCmdToken, CMICmnMIResultRecord::eResultClass_Error,
       valueResult);


### PR DESCRIPTION
Errors messages as coming from the LLDB may contain new line characters,
which are forbidden inside of the MI reply and must be escaped in the
output.

This fixes a problem where LLDB would return the Status with a multiline
string and Eclipse would show only the first line of the message, trimming
the rest.